### PR TITLE
[4주차 - 한방향 연결 리스트] 한방향 연결리스트 구현

### DIFF
--- a/w4_singly_linked_list/TimoNode.java
+++ b/w4_singly_linked_list/TimoNode.java
@@ -1,0 +1,28 @@
+package week04;
+
+public class TimoNode {
+
+    private final int key;
+
+    private TimoNode next;
+
+    public TimoNode(int key) {
+        this.key = key;
+    }
+
+    public void changeNext(TimoNode node) {
+        this.next = node;
+    }
+
+    public TimoNode getNextNode() {
+        return next;
+    }
+
+    public boolean hasNextNode() {
+        return next != null;
+    }
+
+    public int getKey() {
+        return this.key;
+    }
+}

--- a/w4_singly_linked_list/TimoSinglyLinkedList.java
+++ b/w4_singly_linked_list/TimoSinglyLinkedList.java
@@ -1,0 +1,97 @@
+package week04;
+
+public class TimoLinkedList {
+
+    private Node head;
+    private int size;
+
+    public void pushFront(Node node) {
+        if (this.isNotEmpty()) {
+            node.changeNext(head);
+        }
+        changeHead(node);
+        increaseSize();
+    }
+
+    public void pushBack(Node node) {
+        if (this.isEmpty()) {
+            changeHead(node);
+
+        } else {
+            Node target = head;
+            while (target.hasNextNode()) {
+                target = target.getNextNode();
+            }
+            target.changeNext(node);
+        }
+        increaseSize();
+    }
+
+    public Node popFront() {
+        if (isEmpty()) throw new IllegalStateException("비어있는 리스트입니다.");
+
+        Node target = head;
+
+        if (head.hasNextNode()) changeHead(head.getNextNode());
+        else changeHead(null);
+
+        decreaseSize();
+        return target;
+    }
+
+    public Node popBack() {
+        if (isEmpty()) throw new IllegalStateException("비어있는 리스트입니다.");
+
+        Node prevNode = null;
+        Node targetNode = head;
+
+        while (targetNode.hasNextNode()) {
+            prevNode = targetNode;
+            targetNode = targetNode.getNextNode();
+        }
+        if (prevNode != null) {
+            prevNode.changeNext(null);
+        }
+        decreaseSize();
+        return targetNode;
+    }
+
+    public Node search(int key) {
+        if (head.getKey() == key) {
+            return head;
+        } else {
+            Node target = head;
+            while (target.hasNextNode()) {
+                if (target.getKey() == key) {
+                    return target;
+                }
+                target = target.getNextNode();
+            }
+        }
+        return null;
+    }
+
+    private boolean isEmpty() {
+        return head == null;
+    }
+
+    private boolean isNotEmpty() {
+        return !isEmpty();
+    }
+
+    public int size() {
+        return this.size;
+    }
+
+    private void increaseSize() {
+        this.size++;
+    }
+
+    private void decreaseSize() {
+        this.size--;
+    }
+
+    private void changeHead(Node node) {
+        this.head = node;
+    }
+}

--- a/w4_singly_linked_list/TimoSinglyLinkedList.java
+++ b/w4_singly_linked_list/TimoSinglyLinkedList.java
@@ -1,11 +1,9 @@
-package week04;
+public class TimoSinglyLinkedList {
 
-public class TimoLinkedList {
-
-    private Node head;
+    private TimoNode head;
     private int size;
 
-    public void pushFront(Node node) {
+    public void pushFront(TimoNode node) {
         if (this.isNotEmpty()) {
             node.changeNext(head);
         }
@@ -13,12 +11,12 @@ public class TimoLinkedList {
         increaseSize();
     }
 
-    public void pushBack(Node node) {
+    public void pushBack(TimoNode node) {
         if (this.isEmpty()) {
             changeHead(node);
 
         } else {
-            Node target = head;
+            TimoNode target = head;
             while (target.hasNextNode()) {
                 target = target.getNextNode();
             }
@@ -27,10 +25,10 @@ public class TimoLinkedList {
         increaseSize();
     }
 
-    public Node popFront() {
+    public TimoNode popFront() {
         if (isEmpty()) throw new IllegalStateException("비어있는 리스트입니다.");
 
-        Node target = head;
+        TimoNode target = head;
 
         if (head.hasNextNode()) changeHead(head.getNextNode());
         else changeHead(null);
@@ -39,11 +37,11 @@ public class TimoLinkedList {
         return target;
     }
 
-    public Node popBack() {
+    public TimoNode popBack() {
         if (isEmpty()) throw new IllegalStateException("비어있는 리스트입니다.");
 
-        Node prevNode = null;
-        Node targetNode = head;
+        TimoNode prevNode = null;
+        TimoNode targetNode = head;
 
         while (targetNode.hasNextNode()) {
             prevNode = targetNode;
@@ -56,11 +54,11 @@ public class TimoLinkedList {
         return targetNode;
     }
 
-    public Node search(int key) {
+    public TimoNode search(int key) {
         if (head.getKey() == key) {
             return head;
         } else {
-            Node target = head;
+            TimoNode target = head;
             while (target.hasNextNode()) {
                 if (target.getKey() == key) {
                     return target;
@@ -91,7 +89,7 @@ public class TimoLinkedList {
         this.size--;
     }
 
-    private void changeHead(Node node) {
+    private void changeHead(TimoNode node) {
         this.head = node;
     }
 }

--- a/w4_singly_linked_list/TimoSinglyLinkedListTest.java
+++ b/w4_singly_linked_list/TimoSinglyLinkedListTest.java
@@ -1,0 +1,122 @@
+package week04;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TimoLinkedListTest {
+
+    @DisplayName("제일 앞에 요소 삽입")
+    @Test
+    void pushFront() {
+        //given
+        TimoLinkedList linkedListEmpty = new TimoLinkedList();
+        TimoLinkedList linkedListAppend = new TimoLinkedList();
+        Node fistNode = new Node(1);
+        Node secondNode = new Node(1);
+
+        //when
+        linkedListEmpty.pushFront(fistNode);
+        linkedListAppend.pushFront(fistNode);
+        linkedListAppend.pushFront(secondNode);
+
+        //then
+        assertThat(linkedListEmpty.size()).isEqualTo(1);
+        assertThat(linkedListAppend.size()).isEqualTo(2);
+    }
+
+    @DisplayName("제일 뒤에 요소 삽입")
+    @Test
+    void pushBack() {
+        //given
+        TimoLinkedList linkedListEmpty = new TimoLinkedList();
+        Node firstNode = new Node(1);
+
+        TimoLinkedList linkedListAppend = new TimoLinkedList();
+        Node secondNode = new Node(2);
+
+        //when
+        linkedListEmpty.pushBack(firstNode);
+        linkedListAppend.pushBack(firstNode);
+        linkedListAppend.pushBack(secondNode);
+
+        //then
+        assertThat(linkedListEmpty.size()).isEqualTo(1);
+        assertThat(linkedListAppend.size()).isEqualTo(2);
+    }
+
+    @DisplayName("제일 첫 요소 제거")
+    @Test
+    void popFirst() {
+        //given
+        TimoLinkedList linkedList = new TimoLinkedList();
+        Node firstNode = new Node(1);
+        Node secondNode = new Node(2);
+        Node thirdNode = new Node(3);
+
+        linkedList.pushFront(thirdNode);
+        linkedList.pushFront(secondNode);
+        linkedList.pushFront(firstNode);
+
+        //when
+        Node popNode = linkedList.popFront();
+
+        //then
+        assertThat(popNode).isEqualTo(firstNode);
+    }
+
+    @DisplayName("제일 마지막 요소 제거")
+    @Test
+    void popLast() {
+        //given
+        TimoLinkedList linkedList = new TimoLinkedList();
+        Node firstNode = new Node(1);
+        Node secondNode = new Node(2);
+        Node thirdNode = new Node(3);
+
+        linkedList.pushBack(firstNode);
+        linkedList.pushBack(secondNode);
+        linkedList.pushBack(thirdNode);
+
+        //when
+        Node popNode = linkedList.popBack();
+
+        //then
+        assertThat(popNode).isEqualTo(thirdNode);
+        assertThat(linkedList.size()).isEqualTo(2);
+    }
+
+    @DisplayName("비어있는 리스트에서 popFirst()를 호출하면 예외 발생")
+    @Test
+    void popFirstException() {
+        //given
+        TimoLinkedList linkedList = new TimoLinkedList();
+
+        //when & then
+        assertThatThrownBy(linkedList::popFront)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("비어있는 리스트입니다.");
+        assertThatThrownBy(linkedList::popBack)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("비어있는 리스트입니다.");
+    }
+
+    @DisplayName("해당 KEY를 가진 노드 탐색")
+    @Test
+    void search() {
+        //given
+        TimoLinkedList linkedList = new TimoLinkedList();
+        linkedList.pushBack(new Node(1));
+        linkedList.pushBack(new Node(2));
+        linkedList.pushBack(new Node(3));
+
+        //when
+        Node findNode =  linkedList.search(2);
+
+        //then
+        assertThat(findNode.getKey()).isEqualTo(2);
+        assertThat(linkedList.search(9)).isNull();
+    }
+}

--- a/w4_singly_linked_list/TimoSinglyLinkedListTest.java
+++ b/w4_singly_linked_list/TimoSinglyLinkedListTest.java
@@ -1,21 +1,19 @@
-package week04;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class TimoLinkedListTest {
+class TimoSinglyLinkedListTest {
 
     @DisplayName("제일 앞에 요소 삽입")
     @Test
     void pushFront() {
         //given
-        TimoLinkedList linkedListEmpty = new TimoLinkedList();
-        TimoLinkedList linkedListAppend = new TimoLinkedList();
-        Node fistNode = new Node(1);
-        Node secondNode = new Node(1);
+        TimoSinglyLinkedList linkedListEmpty = new TimoSinglyLinkedList();
+        TimoSinglyLinkedList linkedListAppend = new TimoSinglyLinkedList();
+        TimoNode fistNode = new TimoNode(1);
+        TimoNode secondNode = new TimoNode(1);
 
         //when
         linkedListEmpty.pushFront(fistNode);
@@ -31,11 +29,11 @@ class TimoLinkedListTest {
     @Test
     void pushBack() {
         //given
-        TimoLinkedList linkedListEmpty = new TimoLinkedList();
-        Node firstNode = new Node(1);
+        TimoSinglyLinkedList linkedListEmpty = new TimoSinglyLinkedList();
+        TimoNode firstNode = new TimoNode(1);
 
-        TimoLinkedList linkedListAppend = new TimoLinkedList();
-        Node secondNode = new Node(2);
+        TimoSinglyLinkedList linkedListAppend = new TimoSinglyLinkedList();
+        TimoNode secondNode = new TimoNode(2);
 
         //when
         linkedListEmpty.pushBack(firstNode);
@@ -51,17 +49,17 @@ class TimoLinkedListTest {
     @Test
     void popFirst() {
         //given
-        TimoLinkedList linkedList = new TimoLinkedList();
-        Node firstNode = new Node(1);
-        Node secondNode = new Node(2);
-        Node thirdNode = new Node(3);
+        TimoSinglyLinkedList linkedList = new TimoSinglyLinkedList();
+        TimoNode firstNode = new TimoNode(1);
+        TimoNode secondNode = new TimoNode(2);
+        TimoNode thirdNode = new TimoNode(3);
 
         linkedList.pushFront(thirdNode);
         linkedList.pushFront(secondNode);
         linkedList.pushFront(firstNode);
 
         //when
-        Node popNode = linkedList.popFront();
+        TimoNode popNode = linkedList.popFront();
 
         //then
         assertThat(popNode).isEqualTo(firstNode);
@@ -71,17 +69,17 @@ class TimoLinkedListTest {
     @Test
     void popLast() {
         //given
-        TimoLinkedList linkedList = new TimoLinkedList();
-        Node firstNode = new Node(1);
-        Node secondNode = new Node(2);
-        Node thirdNode = new Node(3);
+        TimoSinglyLinkedList linkedList = new TimoSinglyLinkedList();
+        TimoNode firstNode = new TimoNode(1);
+        TimoNode secondNode = new TimoNode(2);
+        TimoNode thirdNode = new TimoNode(3);
 
         linkedList.pushBack(firstNode);
         linkedList.pushBack(secondNode);
         linkedList.pushBack(thirdNode);
 
         //when
-        Node popNode = linkedList.popBack();
+        TimoNode popNode = linkedList.popBack();
 
         //then
         assertThat(popNode).isEqualTo(thirdNode);
@@ -92,7 +90,7 @@ class TimoLinkedListTest {
     @Test
     void popFirstException() {
         //given
-        TimoLinkedList linkedList = new TimoLinkedList();
+        TimoSinglyLinkedList linkedList = new TimoSinglyLinkedList();
 
         //when & then
         assertThatThrownBy(linkedList::popFront)
@@ -107,13 +105,13 @@ class TimoLinkedListTest {
     @Test
     void search() {
         //given
-        TimoLinkedList linkedList = new TimoLinkedList();
-        linkedList.pushBack(new Node(1));
-        linkedList.pushBack(new Node(2));
-        linkedList.pushBack(new Node(3));
+        TimoSinglyLinkedList linkedList = new TimoSinglyLinkedList();
+        linkedList.pushBack(new TimoNode(1));
+        linkedList.pushBack(new TimoNode(2));
+        linkedList.pushBack(new TimoNode(3));
 
         //when
-        Node findNode =  linkedList.search(2);
+        TimoNode findNode =  linkedList.search(2);
 
         //then
         assertThat(findNode.getKey()).isEqualTo(2);


### PR DESCRIPTION
- `pushFront()` `pushBack()` `popFront()` `popBack()` `search()` 메소드를 구현하였습니다.
- 비어있는 리스트라면 `pop()` 할 수 없도록 예외처리 하였습니다.
- 객체 내부에서 속성 값을 다룰 때도 `private` 메서드를 사용하도록 구현했습니다.
- `search()` 메소드의 알고리즘이 썩 마음에 들진 않네요..! (좋은 의견 환영합니다)