### PR TITLE
[5주차 - 양방향 연결 리스트] 양방향 연결 리스트 구현

### DIFF
--- a/w5_daeun_doubly_linked_list/DoublyLinkedList.java
+++ b/w5_daeun_doubly_linked_list/DoublyLinkedList.java
@@ -1,0 +1,87 @@
+package grace.datastructuresgroupstudy.week5;
+
+// 원형 양방향 연결 리스트 구현
+public class DoublyLinkedList {
+
+  private final Node head =  new Node(null); // 더미 null
+  private int size;
+
+
+  public void originPushFront(Node newNode) {
+    Node nextNode = this.head.getNext();
+    newNode.changePrev(this.head);
+    if(size != 0) {
+      newNode.changeNext(nextNode);
+      nextNode.changePrev(newNode);
+    } else {
+      newNode.changeNext(this.head);
+      this.head.changePrev(newNode);
+    }
+    this.head.changeNext(newNode);
+    this.size++;
+  }
+
+  public void splice(Node a, Node b, Node x) {
+
+    Node aPrev = a.getPrev();
+    Node bNext = b.getNext();
+
+    // 자르기
+    if(aPrev != null && bNext != null) {
+      aPrev.changeNext(bNext);
+      bNext.changePrev(aPrev);
+    }
+
+    // x 뒤에 a~b 삽입
+    Node xNext = x.getNext();
+    x.changeNext(a);
+    a.changePrev(x);
+    b.changeNext(xNext);
+    xNext.changePrev(b);
+
+  }
+
+  // 노드a 를 노드x 뒤로 이동
+  public void moveAfter(Node a, Node x) {
+    this.splice(a, a, x);
+  }
+
+  // 노드a 를 노드x 앞으로 이동
+  public void moveBefore(Node a, Node x) {
+    this.splice(a, a, x.getPrev());
+  }
+
+  // key로 새로운 노드를 만들어서 x 뒤에 삽입
+  public void insertAfter(Node x, String key) {
+    this.moveAfter(new Node(key), x);
+    this.size++;
+  }
+
+  // key로 새로운 노드를 만들어서 x 전에 삽입
+  public void insertBefore(Node x, String key) {
+    this.moveBefore(new Node(key), x);
+    this.size++;
+  }
+
+  // key로 새로운 노드를 만들어서 헤드노드(더미) 다음에 삽입
+  public void pushFront(String key) {
+    this.insertAfter(this.head, key);
+  }
+
+  // key로 새로운 노드를 만들어서 헤드노드(더미) 전 (=테일 노드 다음)에 삽입
+  public void pushBack(String key) {
+    this.insertBefore(this.head, key);
+  }
+
+  public String[] toArray() {
+    String[] array = new String[size];
+    Node x = head.getNext();
+    for(int i=0; i<size; i++) {
+      array[i] = x.getKey();
+      x = x.getNext();
+    }
+    return array;
+  }
+
+
+}

--- a/w5_daeun_doubly_linked_list/DoublyLinkedListTest.java
+++ b/w5_daeun_doubly_linked_list/DoublyLinkedListTest.java
@@ -1,0 +1,194 @@
+package grace.datastructuresgroupstudy.week5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class DoublyLinkedListTest {
+
+  @DisplayName("헤드 노드 앞에 새로운 노드 삽입")
+  @Test
+  void originPushFront() {
+    //given
+    DoublyLinkedList doublyLinkedList = new DoublyLinkedList();
+    Node aNode = new Node("a");
+    Node bNode = new Node("b");
+    Node cNode = new Node("c");
+
+    //when
+    doublyLinkedList.originPushFront(cNode);
+    doublyLinkedList.originPushFront(bNode);
+    doublyLinkedList.originPushFront(aNode);
+
+    //then
+    assertThat(arrayToStr(doublyLinkedList.toArray())).isEqualTo("a-b-c");
+  }
+
+  @DisplayName("splice 연산")
+  @Test
+  void splice() {
+    //given
+    DoublyLinkedList doublyLinkedList = new DoublyLinkedList();
+    Node apNode = new Node("ap");
+    Node aNode = new Node("a");
+    Node anNode = new Node("an");
+    Node bpNode = new Node("bp");
+    Node bNode = new Node("b");
+    Node bnNode = new Node("bn");
+    Node xpNode = new Node("xp");
+    Node xNode = new Node("x");
+    Node xnNode = new Node("xn");
+
+
+    doublyLinkedList.originPushFront(xnNode);
+    doublyLinkedList.originPushFront(xNode);
+    doublyLinkedList.originPushFront(xpNode);
+    doublyLinkedList.originPushFront(bnNode);
+    doublyLinkedList.originPushFront(bNode);
+    doublyLinkedList.originPushFront(bpNode);
+    doublyLinkedList.originPushFront(anNode);
+    doublyLinkedList.originPushFront(aNode);
+    doublyLinkedList.originPushFront(apNode);
+
+    //when
+    doublyLinkedList.splice(aNode, bNode, xNode);
+
+    //then
+    assertThat(arrayToStr(doublyLinkedList.toArray())).isEqualTo("ap-bn-xp-x-a-an-bp-b-xn");
+  }
+
+  @DisplayName("노드a 를 노드x 뒤로 이동")
+  @Test
+  void moveAfter() {
+    //given
+    DoublyLinkedList doublyLinkedList = new DoublyLinkedList();
+    Node aNode = new Node("a");
+    Node bNode = new Node("b");
+    Node cNode = new Node("c");
+    Node xNode = new Node("x");
+
+    doublyLinkedList.originPushFront(xNode);
+    doublyLinkedList.originPushFront(cNode);
+    doublyLinkedList.originPushFront(bNode);
+    doublyLinkedList.originPushFront(aNode);
+
+    //when
+    doublyLinkedList.moveAfter(aNode, xNode);
+
+    //then
+    assertThat(arrayToStr(doublyLinkedList.toArray())).isEqualTo("b-c-x-a");
+  }
+
+  @DisplayName("노드a 를 노드x 앞으로 이동")
+  @Test
+  void moveBefore() {
+    //given
+    DoublyLinkedList doublyLinkedList = new DoublyLinkedList();
+    Node aNode = new Node("a");
+    Node bNode = new Node("b");
+    Node cNode = new Node("c");
+    Node xNode = new Node("x");
+
+    doublyLinkedList.originPushFront(xNode);
+    doublyLinkedList.originPushFront(cNode);
+    doublyLinkedList.originPushFront(bNode);
+    doublyLinkedList.originPushFront(aNode);
+
+    //when
+    doublyLinkedList.moveBefore(aNode, xNode);
+
+    //then
+    assertThat(arrayToStr(doublyLinkedList.toArray())).isEqualTo("b-c-a-x");
+  }
+
+  @DisplayName("key로 새로운 노드를 만들어서 x 뒤에 삽입")
+  @Test
+  void insertAfter() {
+    //given
+    DoublyLinkedList doublyLinkedList = new DoublyLinkedList();
+    Node aNode = new Node("a");
+    Node bNode = new Node("b");
+    Node xNode = new Node("x");
+
+    doublyLinkedList.originPushFront(xNode);
+    doublyLinkedList.originPushFront(bNode);
+    doublyLinkedList.originPushFront(aNode);
+
+    //when
+    doublyLinkedList.insertAfter(xNode, "y");
+
+    //then
+    assertThat(arrayToStr(doublyLinkedList.toArray())).isEqualTo("a-b-x-y");
+  }
+
+  @DisplayName("key로 새로운 노드를 만들어서 x 앞에 삽입")
+  @Test
+  void insertBefore() {
+    //given
+    DoublyLinkedList doublyLinkedList = new DoublyLinkedList();
+    Node aNode = new Node("a");
+    Node bNode = new Node("b");
+    Node xNode = new Node("x");
+
+    doublyLinkedList.originPushFront(xNode);
+    doublyLinkedList.originPushFront(bNode);
+    doublyLinkedList.originPushFront(aNode);
+
+    //when
+    doublyLinkedList.insertBefore(xNode, "y");
+
+    //then
+    assertThat(arrayToStr(doublyLinkedList.toArray())).isEqualTo("a-b-y-x");
+  }
+
+  @DisplayName("key로 새로운 노드를 만들어서 헤드노드(더미) 다음에 삽입")
+  @Test
+  void pushFront() {
+    //given
+    DoublyLinkedList doublyLinkedList = new DoublyLinkedList();
+    Node aNode = new Node("a");
+    Node bNode = new Node("b");
+    Node xNode = new Node("x");
+
+    doublyLinkedList.originPushFront(xNode);
+    doublyLinkedList.originPushFront(bNode);
+    doublyLinkedList.originPushFront(aNode);
+
+    //when
+    doublyLinkedList.pushFront("y");
+
+    //then
+    assertThat(arrayToStr(doublyLinkedList.toArray())).isEqualTo("y-a-b-x");
+  }
+
+  @DisplayName("key로 새로운 노드를 만들어서 헤드노드(더미) 전 (=테일 노드 다음)에 삽입")
+  @Test
+  void pushBack() {
+    //given
+    DoublyLinkedList doublyLinkedList = new DoublyLinkedList();
+    Node aNode = new Node("a");
+    Node bNode = new Node("b");
+    Node xNode = new Node("x");
+
+    doublyLinkedList.originPushFront(xNode);
+    doublyLinkedList.originPushFront(bNode);
+    doublyLinkedList.originPushFront(aNode);
+
+    //when
+    doublyLinkedList.pushBack( "y");
+
+    //then
+    assertThat(arrayToStr(doublyLinkedList.toArray())).isEqualTo("a-b-x-y");
+  }
+
+  private String arrayToStr(String[] keyList) {
+    return Arrays.stream(keyList)
+        .collect(Collectors.joining("-"));
+  }
+}

--- a/w5_daeun_doubly_linked_list/Node.java
+++ b/w5_daeun_doubly_linked_list/Node.java
@@ -1,0 +1,43 @@
+package grace.datastructuresgroupstudy.week5;
+
+public class Node {
+
+  private final String key;
+  private Node prev;
+  private Node next;
+
+  public Node(String key) {
+    this.key = key;
+    this.prev = null;
+    this.next = null;
+  }
+
+  public void changePrev(Node node) {
+    this.prev = node;
+  }
+
+  public void changeNext(Node node) {
+    this.next = node;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public Node getPrev() {
+    return prev;
+  }
+
+  public Node getNext() {
+    return next;
+  }
+
+  @Override
+  public String toString() {
+    return "Node{" +
+        "key=" + key +
+        ", prevKey=" + (prev != null ? prev.getKey() : "") +
+        ", nextKey=" + (next != null ? next.getKey() : "") +
+        '}';
+  }
+}


### PR DESCRIPTION
- 강의에서 교수님이 설명하신대로 원형 연결리스트로 구현해 보았습니다.
- head 의 key는 더미를 상징하는 null로 설정되어있고, 
head 의 prev는 실제 tail 값을 의미하는 Node로 설정되어 있습니다.
- 강의에서 설명한 `splice(),` `moveAfter()`, `moveBefore()`, `insertAfter()`, `insertBefore()`, `pushFront(`), `pushBack()` 메소드를 구현했습니다.
- `originPushFront()` 메소드를 구현하여 처음 값 세팅에 사용하였습니다.
=> 작업 하고 보니 해당 메소드와 `splice()` 메소드를 합쳐서 구현할수 있을것 같긴합니다...